### PR TITLE
Add elm instructions and scaffold basic site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ To run the snippet and see it working, you'll need to open the `example.html` pa
 
 **Client**
 
-// Todo
+1. [Install Elm](https://guide.elm-lang.org/install.html) (follow this entire guide if you can!)
+2. Go into your terminal and navigate to the folder `./client` in this repo. 
+3. Run: `elm reactor`.
+4. Go to `localhost:8000`. Elm should download whatever packages you need to run the project. 
+5. Using elm reactor you can navigate our app. I recommend clicking on the main entry point, which should be `main.elm`. 
 
 **Api**
 

--- a/client/README.md
+++ b/client/README.md
@@ -22,3 +22,12 @@ Let's get setup:
 2. Go into your terminal and navigate to `./client`. Run: `elm reactor`.
 3. Go to `localhost:8000`. Elm should download whatever packages you need to run the project. 
 4. Using elm reactor you can navigate our app. I recommend clicking on the main entry point, which should be `main.elm`. 
+
+
+## Resources
+
+I have been reading and listening to talks / videos about elm for a while. I will add resources about them as I go.
+
+- The [elm docs](http://elm-lang.org/docs) are really good.
+- More [elm docs](https://guide.elm-lang.org/install.html).
+- [Introduction to the elm architecture] (https://css-tricks.com/introduction-elm-architecture-build-first-application/) - I like this tutorial. I'm using it as I write this!

--- a/client/main.elm
+++ b/client/main.elm
@@ -1,0 +1,69 @@
+module Main exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+
+
+main : Program Never Model Msg
+main =
+    Html.beginnerProgram { model = model, view = view, update = update }
+
+
+{- Let's define our model! We need the following:
+   A type alias
+   To set the type to the function "model"
+   To actually write the model function
+ -}
+
+
+type alias Model =
+    { buttonMessage : String
+    , buttonOn : Bool
+    }
+
+
+model : Model
+model =
+    { buttonMessage = "I am on"
+    , buttonOn = False
+    }
+
+
+
+{-Update Section. We need the following:
+    * A union type for listing our actions
+    * Set the update function have a type
+    * To write the update function
+-}
+
+
+type Msg
+    = ToggleButton
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        ToggleButton ->
+            { model
+                | buttonOn = not model.buttonOn
+                , buttonMessage = createButtonText model.buttonOn
+            }
+
+
+view : Model -> Html Msg
+view model =
+    button [ onClick ToggleButton ] [ text model.buttonMessage ]
+
+
+
+-- LITTLE FUNCTIONS THAT MAKE UP OUR GOOD LIFE --
+
+
+createButtonText : Bool -> String
+createButtonText boolState =
+    if boolState then
+        "I am on"
+    else
+        "I am off"


### PR DESCRIPTION
- this commit adds some instructions to the main readme for getting
started with Elm.
- I experimented with creating a little toggle button to become familiar
with the elm syntax.
- Eventually this will be replaced with some basic functionality based on
the wireframe for client (that does not exist currently)
- Clean up comments to be proper multiline