### PR TITLE
Added issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Possible Implementation
+<!--- Not required, but suggest an idea for implementing addition or change -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,5 +3,8 @@
 ## Detailed Description
 <!--- Provide a detailed description of the change or addition you are proposing -->
 
+## Screenshots
+<!-- Provide screenshots if it makes sense! Showing a bug, or an example of the change you want -->
+
 ## Possible Implementation
 <!--- Not required, but suggest an idea for implementing addition or change -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Summary
+<!--- Describe your changes in detail -->
+
+## Checklist
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have updated the documentation to reflect my changes
+- [ ] I have added tests to cover my changes (if relevant)
+- [ ] All new and existing tests passed

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Summary
 <!--- Describe your changes in detail -->
 
+## Screenshots
+<!-- Provide screenshots if it makes sense! For instance if you've made UI changes. -->
+
 ## Checklist
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have updated the documentation to reflect my changes


### PR DESCRIPTION
Issue and pull request templates help keep a consistent format and remind people about the contribution guidelines without them checking manually. Github will take these templates and use then as the default text for any new issue or pull request made.

This addresses Issue #32.