### PR TITLE
Incrementing counters no longer causes the emoji bar to jitter (Issue #41)

### DIFF
--- a/snippet/index.js
+++ b/snippet/index.js
@@ -114,21 +114,36 @@
       }
 
       .emojion__single {
+        display: flex;
+        align-items: center;
         background: #fff;
         border-bottom: 1px solid #eee;
         border-left: 0;
         border-right: 0;
         border-top: 1px solid #eee;
         box-sizing: content-box;
-        display: inline-block;
-        flex: 1 0 auto;
+        flex: 1;
         font-size: 16px;
         margin: 0;
         min-width: 7px;
         outline: 0;
         padding: 5px 10px 8px;
         transition: background 0.25s ease;
-        width: auto;
+      }
+
+      .emojion__icon,
+      .emojion__count {
+        flex: 1;
+      }
+
+      .emojion__icon {
+        text-align: right;
+        margin-right: 4px;
+      }
+
+      .emojion__count {
+        text-align: left;
+        margin-left: 4px;
       }
 
       .emojion__single:first-of-type {
@@ -164,7 +179,11 @@
   function getAllIds(state) {
     const ids = [...document.querySelectorAll("[class]")]; // -> converts nodelist to array
     // Check if EMOJION_ID is present and if NO_EMOJION_ID class is not declared
-    const mounts = ids.filter(node => node.className.includes(EMOJION_ID) && !node.className.includes(NO_EMOJION_ID));
+    const mounts = ids.filter(
+      node =>
+        node.className.includes(EMOJION_ID) &&
+        !node.className.includes(NO_EMOJION_ID)
+    );
     state.dom.mounts = mounts;
     return state;
   }
@@ -178,7 +197,7 @@
   function makeEmojionBars(state) {
     state.dom.mounts.forEach(mount => {
       //This line of code assumes that 'emojion' has to be first class
-      let mountClassName = mount.className.split(' ')[0];
+      let mountClassName = mount.className.split(" ")[0];
       state.emojis[mountClassName] = EMOJION_STAMP();
     });
     return state;
@@ -200,7 +219,7 @@
 
       // set a value on our html attribute (ie. class = " emojion__container") -> add to dom element
       containerClass.value = "emojion__container";
-      containerMapId.value = mount.className.split(' ')[0];
+      containerMapId.value = mount.className.split(" ")[0];
       emojiContainer.setAttributeNode(containerClass);
       emojiContainer.setAttributeNode(containerMapId);
 
@@ -228,7 +247,7 @@
           //  unique id to DOM + Data Strutcure => for adding click el's later.
           emoji.id = `${id}_${index}`;
           return `<button id="${emoji.id}" class="emojion__single">
-            ${emoji.icon} ${emoji.count}
+            <span class="emojion__icon">${emoji.icon}</span><span class="emojion__count">${emoji.count}</span>
           </button>`;
         })
         .join(""); // remove commas between elements


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I changed some of the styles and html regarding the emoji buttons so that they no longer jitter horizontally upon incrementing counters.

## Summary
<!--- Describe your changes in detail -->
I made the "emojion__single" buttons "flex: 1" instead of "flex: 1 0 auto". This was the critical change that prevented surrounding emojis from jittering. However, the emoji being clicked on was still dancing around in place. So I made the buttons display flex instead of inline-block in order to style the button content. I wrapped the icon and count in spans so that I could style them in such a way that they no longer move on click.

## Screenshots
<!-- Provide screenshots if it makes sense! For instance if you've made UI changes. -->

## Checklist
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation to reflect my changes
- [ ] I have added tests to cover my changes (if relevant)
- [ ] All new and existing tests passed
