### PR TITLE
Add basic client UI

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -1,33 +1,79 @@
 module Main exposing (main)
 
+import Set exposing (Set)
 import Css
-import Html exposing (Html, div, header, h1, p, text)
-import Html.Attributes exposing (..)
-
-
--- import Html.Events exposing (..)
-
+import Html exposing (Attribute, Html, button, div, header, h1, input, label, li, p, text, ul)
+import Html.Attributes exposing (checked, type_)
+import Html.Events as Events exposing (onCheck, onClick, onWithOptions)
+import Json.Decode as JD
+import Zipper as Zip exposing (Zipper)
 import Style
 
 
 main : Program Never Model Msg
 main =
-    Html.beginnerProgram { model = 0, update = update, view = view }
+    Html.beginnerProgram { model = init, update = update, view = view }
 
 
 type Msg
-    = Increment
+    = Select Emojion
+    | Deselect Emojion
+    | ReorderTarget Int
+    | ReorderPrev
+    | ReorderNext
 
 
 type alias Model =
-    Int
+    { available : List Emojion
+    , selected : Zipper Emojion
+    , emojionsSize : Int
+    , error : Maybe String
+    }
+
+
+type alias Emojion =
+    String
+
+
+init : Model
+init =
+    { available = [ "a", "b", "c", "d", "e", "f", "g", "h", "i" ]
+    , selected = Zip.empty
+    , emojionsSize = 5
+    , error = Nothing
+    }
 
 
 update : Msg -> Model -> Model
 update msg model =
     case msg of
-        Increment ->
-            model + 1
+        Select emojion ->
+            if Zip.length model.selected >= model.emojionsSize then
+                { model | error = Just "Your Emojion bar is full, please deselect an emoji to make room." }
+            else
+                { model | selected = Zip.append emojion model.selected }
+
+        Deselect emojion ->
+            { model | selected = Zip.filter ((/=) emojion) model.selected }
+
+        ReorderTarget index ->
+            Zip.zipTo index model.selected
+                |> maybeUpdateSelected model
+
+        ReorderPrev ->
+            Zip.moveBy -1 model.selected
+                |> maybeUpdateSelected model
+
+        ReorderNext ->
+            Zip.moveBy 1 model.selected
+                |> maybeUpdateSelected model
+
+
+maybeUpdateSelected : Model -> Maybe (Zipper Emojion) -> Model
+maybeUpdateSelected model maybe =
+    maybe
+        |> Maybe.map (\selected -> { model | selected = selected })
+        |> Maybe.withDefault model
 
 
 view : Model -> Html Msg
@@ -39,7 +85,83 @@ view model =
             , p []
                 [ text "Custom Emoji Reaction Bars for your sweet site." ]
             ]
+        , selectedView model.selected
+        , button [ onClick ReorderPrev ] [ text "Up" ]
+        , button [ onClick ReorderNext ] [ text "Down" ]
+        , availableView (Zip.toList model.selected) model.available
         ]
+
+
+selectedView : Zipper Emojion -> Html Msg
+selectedView emojions =
+    let
+        reorderSelect =
+            Zip.index emojions
+    in
+        ul []
+            (emojions
+                |> Zip.toList
+                |> List.indexedMap (selectedLi reorderSelect)
+            )
+
+
+selectedLi : Int -> Int -> Emojion -> Html Msg
+selectedLi reorderSelect index emojion =
+    li [ onClick (ReorderTarget index) ]
+        [ emojionView emojion
+        , if index == reorderSelect then
+            text "selected"
+          else
+            text ""
+        ]
+
+
+availableView : List Emojion -> List Emojion -> Html Msg
+availableView selectedList available =
+    let
+        selected =
+            Set.fromList selectedList
+    in
+        ul [] (List.map (availableLi selected) available)
+
+
+availableLi : Set Emojion -> Emojion -> Html Msg
+availableLi selectedSet emojion =
+    let
+        selected =
+            Set.member emojion selectedSet
+    in
+        li []
+            [ label []
+                [ input
+                    [ type_ "checkbox"
+                    , checked selected
+                    , onCheckSuppressed (selectSwitch emojion)
+                    ]
+                    []
+                , emojionView emojion
+                ]
+            ]
+
+
+onCheckSuppressed : (Bool -> msg) -> Attribute msg
+onCheckSuppressed f =
+    onWithOptions "click"
+        { stopPropagation = False, preventDefault = True }
+        (JD.map f Events.targetChecked)
+
+
+selectSwitch : Emojion -> Bool -> Msg
+selectSwitch emojion bool =
+    if bool then
+        Select emojion
+    else
+        Deselect emojion
+
+
+emojionView : Emojion -> Html msg
+emojionView emojion =
+    div [] [ text emojion ]
 
 
 styles : List Css.Mixin -> Html.Attribute msg

--- a/client/Zipper.elm
+++ b/client/Zipper.elm
@@ -1,6 +1,59 @@
-module Zipper exposing (Zipper, empty, zipTo, zipBy, moveBy, append, length, filter, toList, get, put, index, fromList, zipNext, zipPrev)
+module Zipper
+    exposing
+        ( Zipper
+        , empty
+        , zipTo
+        , zipBy
+        , moveBy
+        , append
+        , length
+        , filter
+        , apply
+        , toList
+        , get
+        , put
+        , index
+        , fromList
+        , zipNext
+        , zipPrev
+        )
+
+{-| Zippers are data structures which encode a position and allow for fast access to that position.
+
+Examples:
+
+```
+[1, 2, 3, 4, 5] |> fromList |> get == Just 1
+
+[1, 2, 3, 4, 5] |> fromList |> zipNext |> zipNext |> get == Just 3
+
+[1, 2, 3, 4, 5] |> fromList |> zipNext |> zipNext |> put 0 |> toList == [1, 2, 0, 3, 4, 5]
+```
+
+@docs Zipper
+
+# Creation and Escape
+@docs empty, fromList, toList
+
+# Current Item Operations
+@docs get, put
+
+# Zipping
+@docs zipNext, zipPrev, zipTo, zipBy
+
+# Moving Elements
+@docs moveBy
+
+# Collection Operations
+@docs filter, apply
+
+# Information
+@docs length, index
+-}
 
 
+{-| A list zipper which can be empty and can have a position past the tail end of the list.
+-}
 type Zipper a
     = Zipper (List a) (List a)
 
@@ -10,11 +63,15 @@ empty =
     Zipper [] []
 
 
+{-| Put the zipper at an absolute position. Zipping out of range fails with `Nothing`.
+-}
 zipTo : Int -> Zipper a -> Maybe (Zipper a)
 zipTo index (Zipper prevs nexts) =
     zipBy (index - List.length prevs) (Zipper prevs nexts)
 
 
+{-| Put the zipper at a position relative to the current position. Zipping out of range fails with `Nothing`.
+-}
 zipBy : Int -> Zipper a -> Maybe (Zipper a)
 zipBy amount zipper =
     if amount > 0 then
@@ -27,6 +84,8 @@ zipBy amount zipper =
         Just zipper
 
 
+{-| Put the zipper at a position one previous to the current. Zipping out of range fails with `Nothing`.
+-}
 zipPrev : Zipper a -> Maybe (Zipper a)
 zipPrev (Zipper prevs nexts) =
     case prevs of
@@ -37,6 +96,8 @@ zipPrev (Zipper prevs nexts) =
             Just (Zipper xs (x :: nexts))
 
 
+{-| Put the zipper at a position one after the current. Zipping out of range fails with `Nothing`.
+-}
 zipNext : Zipper a -> Maybe (Zipper a)
 zipNext (Zipper prevs nexts) =
     case nexts of
@@ -47,6 +108,8 @@ zipNext (Zipper prevs nexts) =
             Just (Zipper (x :: prevs) xs)
 
 
+{-| Move an item a relative distance. Moving out of range fails with `Nothing`
+-}
 moveBy : Int -> Zipper a -> Maybe (Zipper a)
 moveBy amount (Zipper prevs nexts) =
     case nexts of
@@ -58,6 +121,8 @@ moveBy amount (Zipper prevs nexts) =
                 |> Maybe.map (put x)
 
 
+{-| Add an item to the end of the list.
+-}
 append : a -> Zipper a -> Zipper a
 append x (Zipper prevs nexts) =
     Zipper prevs (nexts ++ [ x ])
@@ -68,11 +133,15 @@ length (Zipper prevs nexts) =
     List.length prevs + List.length nexts
 
 
-apply : (List a -> List a) -> Zipper a -> Zipper a
+{-| Apply a function which transforms a list. Expects that the function handles each element independently so a properly typed `fold` may have unexpected results.
+-}
+apply : (List a -> List b) -> Zipper a -> Zipper b
 apply f (Zipper prevs nexts) =
     Zipper (f prevs) (f nexts)
 
 
+{-| Drops items for which the function produces `False`.
+-}
 filter : (a -> Bool) -> Zipper a -> Zipper a
 filter f =
     apply (List.filter f)
@@ -83,21 +152,29 @@ toList (Zipper prevs nexts) =
     List.reverse prevs ++ nexts
 
 
+{-| Convert a list into a Zipper. Sets the initial position to 0.
+-}
 fromList : List a -> Zipper a
 fromList xs =
     Zipper [] xs
 
 
+{-| Get the item at the current position. Fails with `Nothing` if in a position beyond the tail end of the list.
+-}
 get : Zipper a -> Maybe a
 get (Zipper _ nexts) =
     List.head nexts
 
 
+{-| Put an item at the current position. The current item is pushed toward the tail.
+-}
 put : a -> Zipper a -> Zipper a
 put x (Zipper prevs nexts) =
     Zipper prevs (x :: nexts)
 
 
+{-| The index of the zipper's current position.
+-}
 index : Zipper a -> Int
 index (Zipper prevs _) =
     List.length prevs

--- a/client/Zipper.elm
+++ b/client/Zipper.elm
@@ -1,0 +1,103 @@
+module Zipper exposing (Zipper, empty, zipTo, zipBy, moveBy, append, length, filter, toList, get, put, index, fromList, zipNext, zipPrev)
+
+
+type Zipper a
+    = Zipper (List a) (List a)
+
+
+empty : Zipper a
+empty =
+    Zipper [] []
+
+
+zipTo : Int -> Zipper a -> Maybe (Zipper a)
+zipTo index (Zipper prevs nexts) =
+    zipBy (index - List.length prevs) (Zipper prevs nexts)
+
+
+zipBy : Int -> Zipper a -> Maybe (Zipper a)
+zipBy amount zipper =
+    if amount > 0 then
+        zipNext zipper
+            |> Maybe.andThen (zipBy (amount - 1))
+    else if amount < 0 then
+        zipPrev zipper
+            |> Maybe.andThen (zipBy (amount + 1))
+    else
+        Just zipper
+
+
+zipPrev : Zipper a -> Maybe (Zipper a)
+zipPrev (Zipper prevs nexts) =
+    case prevs of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            Just (Zipper xs (x :: nexts))
+
+
+zipNext : Zipper a -> Maybe (Zipper a)
+zipNext (Zipper prevs nexts) =
+    case nexts of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            Just (Zipper (x :: prevs) xs)
+
+
+moveBy : Int -> Zipper a -> Maybe (Zipper a)
+moveBy amount (Zipper prevs nexts) =
+    case nexts of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            zipBy amount (Zipper prevs xs)
+                |> Maybe.map (put x)
+
+
+append : a -> Zipper a -> Zipper a
+append x (Zipper prevs nexts) =
+    Zipper prevs (nexts ++ [ x ])
+
+
+length : Zipper a -> Int
+length (Zipper prevs nexts) =
+    List.length prevs + List.length nexts
+
+
+apply : (List a -> List a) -> Zipper a -> Zipper a
+apply f (Zipper prevs nexts) =
+    Zipper (f prevs) (f nexts)
+
+
+filter : (a -> Bool) -> Zipper a -> Zipper a
+filter f =
+    apply (List.filter f)
+
+
+toList : Zipper a -> List a
+toList (Zipper prevs nexts) =
+    List.reverse prevs ++ nexts
+
+
+fromList : List a -> Zipper a
+fromList xs =
+    Zipper [] xs
+
+
+get : Zipper a -> Maybe a
+get (Zipper _ nexts) =
+    List.head nexts
+
+
+put : a -> Zipper a -> Zipper a
+put x (Zipper prevs nexts) =
+    Zipper prevs (x :: nexts)
+
+
+index : Zipper a -> Int
+index (Zipper prevs _) =
+    List.length prevs


### PR DESCRIPTION
Implements a basic client UI. No styling has been attempted. The UI displays a list of available emoji which can be toggled for selection and a separate list of selected emoji.

Maximum selection size is enforced. One can click on an item in the selected row and then press the buttons to move its position in the selected order.

To be clear, there is no styling, so it looks horrible and provides poor feedback on what you can do.